### PR TITLE
Atualiza para API mais recente do I2S

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -1,28 +1,30 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-static const i2s_port_t i2s_num = I2S_NUM_0; // i2s port number
+static i2s_chan_handle_t tx_handle;
+static const i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(
+    I2S_NUM_AUTO,
+    I2S_ROLE_MASTER
+);
 
-
-static const i2s_config_t i2s_config = {
-    .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
-    .sample_rate = 44100,
-    .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
-    .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
-    .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB),
-    .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // high interrupt priority
-    .dma_buf_count = 8,                       // 8 buffers
-    .dma_buf_len = 1024,                      // 1K per buffer, so 8K of buffer space
-    .use_apll = 0,
-    .tx_desc_auto_clear = true,
-    .fixed_mclk = -1};
-
-
-static const i2s_pin_config_t pin_config = {
-    .bck_io_num = 27,                // The bit clock connectiom, goes to pin 27 of ESP32
-    .ws_io_num = 26,                 // Word select, also known as word select or left right clock
-    .data_out_num = 25,              // Data out from the ESP32, connect to DIN on 38357A
-    .data_in_num = I2S_PIN_NO_CHANGE // we are not interested in I2S data into the ESP32
+static const i2s_std_config_t i2s_config = {
+    .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(44100),
+    .slot_cfg = I2S_STD_MSB_SLOT_DEFAULT_CONFIG(
+        I2S_DATA_BIT_WIDTH_16BIT,
+        I2S_SLOT_MODE_STEREO
+    ),
+    .gpio_cfg = {
+        .mclk = I2S_GPIO_UNUSED,
+        .bclk = GPIO_NUM_27,
+        .ws = GPIO_NUM_26,
+        .dout = GPIO_NUM_25,
+        .din = I2S_GPIO_UNUSED,
+        .invert_flags = {
+            .mclk_inv = false,
+            .bclk_inv = false,
+            .ws_inv = false,
+        },
+    },
 };
 
 #endif

--- a/main/ime-embarcados-lib.cpp
+++ b/main/ime-embarcados-lib.cpp
@@ -1,4 +1,5 @@
-#include "driver/i2s.h"
+#include "driver/i2s_std.h"
+#include "freertos/FreeRTOS.h"
 #include "config.h"
 #include "Phasor.h"
 #include "Oscillator.h"
@@ -16,13 +17,15 @@ void audio_callback()
     int16_t OutputValue = (int16_t)(osc.Process() * Volume);
     //Copia os valores para os dois canais
     Value32Bit = (OutputValue << 16) | (OutputValue & 0xffff);
-    i2s_write(i2s_num, &Value32Bit, 4, &BytesWritten, portMAX_DELAY);
+    i2s_channel_write(tx_handle, &Value32Bit, 4, &BytesWritten, portMAX_DELAY);
 }
 
 extern "C" void app_main(void)
 {
-    i2s_driver_install(i2s_num, &i2s_config, 0, NULL);
-    i2s_set_pin(i2s_num, &pin_config);
+    i2s_new_channel(&chan_cfg, &tx_handle, NULL);
+    i2s_channel_init_std_mode(tx_handle, &i2s_config);
+    i2s_channel_enable(tx_handle);
+
     phs.Init(44100,1);
     osc.Init(44100);
     osc.SetWaveform(Oscillator::WAVE_SIN);


### PR DESCRIPTION
De acordo com a [documentação](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/i2s.html) da Espressif e com alguns "warnings" do compilador, o projeto estava utilizando uma API legada do I2S. Esse commit atualiza o projeto para utilizar a API mais recente.